### PR TITLE
story(issue-241): docs fix learn more button not properly prefixing base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # My Infrastructure as Code Monorepo
 
 This repo contains all infrastructure as code (IaC), services, and documentation
-for my personal home lab. To get a better understanding of all this, the [docs](https://zaba505.github.com/infra)
+for my personal home lab. To get a better understanding of all this, the [docs](https://zaba505.dev/infra)
 site is a perfect place to begin.
 
 P.S. Yes, I know this is widely over-engineered.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,7 +4,7 @@ title: Zaba505's Home Lab
 
 
 {{< blocks/cover title="Welcome to Zaba505's Home Lab Documentation" image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="/docs/overview">
+<a class="btn btn-lg btn-primary me-3 mb-4" href="/infra/docs/overview">
   Learn More <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 </a>
 {{< /blocks/cover >}}


### PR DESCRIPTION
Closes #241 