### PR TITLE
story(issue-858): add milestones, epic labels, and issue dependency tracking

### DIFF
--- a/.claude/skills/plan-adrs/SKILL.md
+++ b/.claude/skills/plan-adrs/SKILL.md
@@ -87,8 +87,29 @@ Once the user approves the list, file one GitHub issue per ADR via `gh issue cre
 - **Title:** `story(adr): {short ADR title} — {capability-name}` (matches the repo's `story(scope): description` convention).
 - **Body:** parent capability link, the TR-NNs to be addressed, a one-paragraph statement of the decision to be made, and a link back to the parent capability planning issue if one exists.
 - **Body must reference `define-adr`** as the skill that will author the ADR and explain that one invocation of `define-adr` produces one ADR file.
+- **Milestone and epic label:** before filing anything, ask the user which milestone these ADRs belong to and which `epic:` labels apply. Run `gh api repos/{owner}/{repo}/milestones --jq '.[].title'` and `gh label list --search epic:` to offer the existing ones. **Never invent a milestone or epic name** — if none fits, ask the user to name it and create it explicitly.
 
-After filing, print the issue numbers/URLs back to the user as a manifest.
+Write each body to a temp file and file with:
+
+```bash
+gh issue create \
+  --title "story(adr): {short ADR title} — {capability-name}" \
+  --body-file "{tmp}/{slug}.md" \
+  --label documentation \
+  --label "epic:{epic}" \
+  --milestone "{milestone}"
+```
+
+After filing, print the issue numbers/URLs back to the user as a manifest, **in dependency order**.
+
+### Cross-referencing sibling ADRs — read this before writing any body
+
+**Refer to sibling ADRs by their GitHub issue number, never by their position in the approved list.** During planning it is natural to number the proposed ADRs 1..N and write "depends on #8" — but `#8` is live GitHub syntax that links to *issue* 8, an unrelated issue. That defect shipped once already across a 20-issue batch and had to be repaired by hand.
+
+Two consequences for how you file:
+
+1. **File in topological order** — an ADR's prerequisites must be filed before it, because their issue numbers do not exist until they are filed.
+2. While drafting, use an unambiguous placeholder such as `{{ADR-8}}` and substitute the real issue number once known. If a number is genuinely not yet available, write the ADR's title in prose rather than any `#`-prefixed token.
 
 ### Issue body template
 
@@ -110,10 +131,21 @@ After filing, print the issue numbers/URLs back to the user as a manifest.
 
 This ADR will be authored via the `define-adr` skill — one invocation per ADR. The skill will identify research tasks, propose options tied back to the TR-NNs above, and stop for the human to make the final selection.
 
+### Depends on
+
+- #{issue} — {sibling ADR title}
+
+<!-- Hard prerequisites ONLY: this ADR cannot be decided until those are.
+     Write "None." when there are none. Boundary splits ("this ADR owns A,
+     that one owns B"), analogies, and decisions this ADR *constrains*
+     downstream are NOT dependencies — leave those in prose. -->
+
 ### Related
 
 #{parent-capability-issue-or-722}
 ```
+
+**Direction matters.** "X must be pinned here so that Y has something to act against" means **Y depends on this ADR**, not the reverse. When in doubt, ask: *could this ADR be authored today if the other were never written?* If yes, it is not a hard dependency.
 
 ## Conversation discipline
 

--- a/.claude/skills/plan-experiences/SKILL.md
+++ b/.claude/skills/plan-experiences/SKILL.md
@@ -92,6 +92,18 @@ Once the user approves the list, file one GitHub issue per experience via `gh is
 - **Title:** `story(ux): {short verb-led journey title} — {capability-name}` (matches the repo's `story(scope): description` convention).
 - **Body:** parent capability link, the persona, the goal in one sentence, and which capability sections (Stakeholders / Triggers / Outputs / Business Rules / Success Criteria) the journey is anchored in.
 - **Body must reference `define-user-experience`** as the skill that will author the UX doc, and explain that one invocation of `define-user-experience` produces one UX file under `docs/content/capabilities/{capability-name}/user-experiences/`.
+- **Milestone and epic label:** before filing anything, ask the user which milestone and which `epic:` labels apply. Offer the existing ones via `gh api repos/{owner}/{repo}/milestones --jq '.[].title'` and `gh label list --search epic:`. **Never invent a milestone or epic name.**
+
+```bash
+gh issue create \
+  --title "story(ux): {short verb-led journey title} — {capability-name}" \
+  --body-file "{tmp}/{slug}.md" \
+  --label documentation \
+  --label "epic:{epic}" \
+  --milestone "{milestone}"
+```
+
+**Refer to sibling experiences by GitHub issue number, never by their position in the approved list** — `#3` is live GitHub syntax and links to issue 3, not to the third journey you planned. Where one journey must be authored before another, file in topological order so the prerequisite's number exists first.
 
 After filing, print the issue numbers/URLs back to the user as a manifest.
 
@@ -123,6 +135,15 @@ After filing, print the issue numbers/URLs back to the user as a manifest.
 ### Authoring
 
 This UX will be authored via the `define-user-experience` skill — one invocation per UX. The skill will elicit persona, goal, entry point, journey, success, and edge cases, and save the doc under `docs/content/capabilities/{capability-name}/user-experiences/{ux-name}.md`.
+
+### Depends on
+
+- #{issue} — {sibling experience title}
+
+<!-- Hard prerequisites ONLY: journeys that must be authored before this one
+     can be. Write "None." when there are none. Journeys that merely touch
+     the same persona or hand off to each other are NOT dependencies —
+     leave those in prose. -->
 
 ### Related
 

--- a/.claude/skills/plan-implementation/SKILL.md
+++ b/.claude/skills/plan-implementation/SKILL.md
@@ -130,6 +130,20 @@ Once approved, file one GitHub issue per task via `gh issue create`. Each issue:
 
 - **Title:** `story(impl): {short verb-led task title} — {capability-name}` (matches the repo's `story(scope): description` convention; `impl` is the implementation-task scope, parallel to `component`, `ux`, `gap`, etc.).
 - **Body:** uses the template below.
+- **Milestone and epic label:** before filing anything, ask the user which milestone and which `epic:` labels apply. Offer the existing ones via `gh api repos/{owner}/{repo}/milestones --jq '.[].title'` and `gh label list --search epic:`. **Never invent a milestone or epic name.**
+
+```bash
+gh issue create \
+  --title "story(impl): {short verb-led task title} — {capability-name}" \
+  --body-file "{tmp}/{slug}.md" \
+  --label documentation \
+  --label "epic:{epic}" \
+  --milestone "{milestone}"
+```
+
+**File in topological order — prerequisites first.** A task's prerequisite issue numbers do not exist until those issues are filed, so a task can only reference prerequisites that were filed before it. Sort the approved task list topologically before the first `gh issue create` call, not after.
+
+Refer to sibling tasks **only by GitHub issue number**, never by their position in the approved list — `#8` is live GitHub syntax and will link to issue 8, not to the eighth task you planned.
 
 After filing, print the issue numbers/URLs back as a manifest, in dependency order.
 
@@ -157,9 +171,16 @@ After filing, print the issue numbers/URLs back as a manifest, in dependency ord
 - [ ] {Test signal — e.g., "Unit tests cover validation paths, integration test exercises the round-trip."}
 - [ ] {Operational signal where relevant — e.g., "Module applies cleanly via `terraform fmt -recursive -check` and a dry-run plan."}
 
-### Prerequisite tasks
+### Depends on
 
-- #{issue-number} — {prerequisite task title}, OR "None."
+- #{issue-number} — {prerequisite task title}
+
+<!-- Hard prerequisites ONLY: tasks that must merge before this one can start.
+     Write "None." when there are none. Tasks that merely touch the same
+     component are NOT dependencies — leave those in prose. -->
+
+<!-- Section name is shared with plan-adrs / plan-experiences / plan-tech-design
+     so dependencies are greppable across every issue type. -->
 
 ### Authoring
 

--- a/.claude/skills/plan-tech-design/SKILL.md
+++ b/.claude/skills/plan-tech-design/SKILL.md
@@ -112,7 +112,22 @@ Once approved, file via `gh issue create`:
 - **One component issue per component**, title `story(component): {component name} — {capability-name}`. Body includes: capability link, the ADR(s) that established this component, the responsibility, and a pointer to `define-component-design` as the authoring skill.
 - **One gap issue per gap**, title `story(gap): {gap name} — {capability-name}`. Body includes: the gap statement, what type of resolution is needed (`define-technical-requirements`, amending `define-adr`, or per-component spec), and a link back to the parent capability planning issue.
 
-Print the issue numbers/URLs back as a manifest.
+**Milestone and epic label:** before filing anything, ask the user which milestone and which `epic:` labels apply. Offer the existing ones via `gh api repos/{owner}/{repo}/milestones --jq '.[].title'` and `gh label list --search epic:`. **Never invent a milestone or epic name.**
+
+```bash
+gh issue create \
+  --title "story(component): {component name} — {capability-name}" \
+  --body-file "{tmp}/{slug}.md" \
+  --label documentation \
+  --label "epic:{epic}" \
+  --milestone "{milestone}"
+```
+
+**File in topological order and refer to sibling issues only by GitHub issue number**, never by their position in the approved list — `#4` is live GitHub syntax and links to issue 4, not to the fourth component you planned. A component that consumes another component's contract can only cite it once that issue exists.
+
+Gap issues generally block the components they touch: file gaps first, then reference their real numbers from the dependent component issues.
+
+Print the issue numbers/URLs back as a manifest, in dependency order.
 
 ### Component issue body template
 
@@ -131,6 +146,15 @@ Print the issue numbers/URLs back as a manifest.
 ### Authoring
 
 This component's design doc will be authored via `define-component-design` — one invocation per component. The doc format is type-specific (e.g. table definition vs. API service). The composed `tech-design.md` will be updated to link to the component design once written.
+
+### Depends on
+
+- #{issue} — {gap or sibling component title}
+
+<!-- Hard prerequisites ONLY: unresolved gaps that block this component, or
+     components whose contract this one consumes. Write "None." when there
+     are none. Components that merely sit near each other in the topology
+     are NOT dependencies — leave those in prose. -->
 
 ### Parent capability
 
@@ -158,6 +182,13 @@ This component's design doc will be authored via `define-component-design` — o
 ### Surfaced during
 
 Composition of `tech-design.md` for [{capability-name}](../docs/content/capabilities/{name}/_index.md).
+
+### Depends on
+
+- #{issue} — {blocking issue title}
+
+<!-- Hard prerequisites ONLY. Write "None." when there are none.
+     Most gaps depend on nothing — they are what everything else waits on. -->
 
 ### Related
 

--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -20,6 +20,15 @@ body:
       required: true
 
   - type: textarea
+    id: depends-on
+    attributes:
+      label: Depends on
+      description: Hard prerequisites only — issues that must be resolved before this story can start. One per line as `- #123 — short title`. Write `None.` if there are none. Merely related work belongs in Related Issues below, not here.
+      placeholder: None.
+    validations:
+      required: false
+
+  - type: textarea
     id: related-issues
     attributes:
       label: Related Issues


### PR DESCRIPTION
## Why

Issue tracking had no grouping or sequencing — 39 open issues, zero milestones, every capability story on the same `documentation` label.

While fixing that, a latent defect surfaced: the ADR stories filed by `plan-adrs` (748–781) referenced sibling ADRs by their **planning ordinal** rather than their issue number. `#8` is live GitHub syntax, so "internal networking (#8)" linked to issue 8 — an unrelated issue. 20 bodies were affected. Nothing in the skills prevented it, so the next capability would have reproduced it verbatim.

## What's in this PR

Repo-side changes only — the four issue-filing skills and the story template:

- **Milestone + epic label** — each skill now emits `--milestone` and `--label epic:*`, and must *ask* which apply rather than invent names.
- **`### Depends on` template** — scoped to hard prerequisites, with explicit guidance on direction ("X is pinned here so Y has something to act against" means **Y** depends on this one, not the reverse) and on what is merely related.
- **Topological filing order** — a prerequisite's issue number doesn't exist until that issue is filed. `plan-implementation` implied this but never said it.
- **No ordinal refs** — siblings are referenced by issue number only.
- **Renamed** `plan-implementation`'s `### Prerequisite tasks` → `### Depends on`, so one grep finds dependencies across every issue type instead of two incompatible spellings.
- **`story.yaml`** gains a matching `Depends on` field.

## Already applied on GitHub (not in this diff)

- 4 milestones; 7 `epic:*` labels; every open issue except #116 assigned exactly one of each.
- All 20 ordinal refs rewritten to real issue numbers. The result is self-validating — #774 now reads "raw persistence #753, object/blob #757, backup #760", and those issues *are* raw storage, object storage, and backup.
- `### Depends on` added to all 35 SHAP ADR issues. Graph verified acyclic: **26 startable now, 9 blocked**.

```
#759 ← 752          #778 ← 750          #764 ← 763
#766/767/768 ← 765  #769 ← 767
#774 ← 753, 757, 760
#776 ← 748, 756, 759, 761   ← the bottleneck
```

#765 (observability meta-ADR) and #752 (compute runtime) are the highest-leverage roots.

## Verification

- All 35 live issue bodies byte-compared against intended output — identical.
- Regression check: no ordinal ref (`#1`–`#40`) survives in any body.
- Dependency graph cycle-checked programmatically.
- `story.yaml` parses; all four skills confirmed to carry both `--milestone` and a `### Depends on` template.
- Docs/Terraform/Go untouched, so no build or test surface is affected.

## Note

`story.yaml` declares `labels: ["story"]`, but every filed issue uses `documentation` and no `story` label exists. Pre-existing inconsistency, left alone here — worth a follow-up.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
