### PR TITLE
story(issue-857): resolve open questions for cross-environment topology

### DIFF
--- a/docs/content/capabilities/self-hosted-application-platform/adrs/0001-cross-environment-topology.md
+++ b/docs/content/capabilities/self-hosted-application-platform/adrs/0001-cross-environment-topology.md
@@ -24,7 +24,7 @@ The plan-tech-design skill refuses to compose tech-design.md until every ADR is 
 -->
 
 **Parent capability:** [Self-Hosted Application Platform]({{< ref "../_index.md" >}})
-**Addresses requirements:** TR-03, TR-17
+**Addresses requirements:** TR-03, TR-17, TR-01, TR-04, TR-18
 
 ## Context and Problem Statement
 
@@ -91,7 +91,39 @@ The initial reading of this topology treated the home lab as the sole host for t
 
 The consistency rule is what keeps this from fragmenting the topology: **placement changes where a workload runs, never how it is reached.** A cloud-hosted tenant application is *not* exposed directly via the cloud provider's public ingress; it sits behind the same Internet-facing edge as a home-lab-hosted one, so mutual-auth and traffic-control duties stay in exactly one tier and the TR-17 external-reachability story is identical in both environments.
 
-Which environment a given tenant lands in is a **placement policy**, deliberately not decided here — see Open Questions.
+Which environment a given tenant lands in is a **placement policy**, deliberately not decided here — it is its own decision, scoped to its own ADR.
+
+**Offering parity sub-decision: environments may expose unequal offering sets; placement is constrained by tenant need.**
+
+[TR-17]({{< ref "../tech-requirements.md#tr-17" >}}) requires each tenant to receive the full inventory, implemented as shared offerings. It does **not** require every offering to exist in every environment. This ADR reads it accordingly: an environment is a valid target for a given tenant when it carries **every offering that tenant actually needs**, not when it mirrors the other environment's catalog.
+
+The alternative — full parity as a precondition for either environment being a valid target — was rejected because it makes every offering added later a *double* build before it can ship at all, converting the duplicated-surface cost recorded below from a bounded cost into an unbounded one. Deliberately unequal environments keep that cost proportional to demand: an offering is built in the second environment when a tenant needing it is placed there, not in advance.
+
+What this buys is bounded duplication; what it costs is that **placement becomes a matching problem**. The platform must therefore know, per environment, which offerings exist, and must refuse a placement whose tenant needs an offering the target environment lacks — a rejection is a correct outcome, not a failure. Making that inventory legible is a tech-design obligation, and the placement-policy ADR consumes it as an input.
+
+**Migration sub-decision: placement is fixed at onboarding; cross-environment migration is not a supported platform operation.**
+
+The consistent-reachability rule above makes moving a tenant between environments *possible* by construction — its reachability story does not change when its placement does. This ADR declines to make it *supported*. Moving a tenant means tearing it down and re-onboarding it in the other environment: an operator-run exercise using the ordinary onboarding path, with no platform-guaranteed data-migration path and no declared downtime budget.
+
+The reason is that first-class migration would obligate **every stateful offering, in both environments, forever** to expose a matching export/import path — a permanent tax on every future offering, paid to serve a case the platform has no demonstrated demand for. Reachability continuity keeps the door open: if migration is later wanted, this decision is reversible without revisiting the topology, because nothing here bakes placement into how a tenant is reached.
+
+**Origin-path sub-decision: the edge→origin hop is mutually authenticated in *both* environments.**
+
+"Reachable only through the edge" is stated above as a property; it is enforced here rather than left as a convention. In both environments the edge→origin hop presents **client certificates the origin validates against the edge vendor's origin-pull trust anchor**, and the origin **refuses any request that does not present one** — so bypassing the edge and reaching an origin directly fails at the TLS layer, not at a firewall rule that could be relaxed.
+
+The public-cloud anchor's realization of this already exists: `cloud/mtls/cloudflare-gcp/` issues the origin keypair, fetches the edge vendor's authenticated-origin-pull CA trust anchor, and stores both in Secret Manager for the origin to consume. The home-lab side must reach the same posture rather than a weaker one; the two differ in realization, not in strength. Deployment surface that terminates edge traffic without this enforcement is non-conforming to this ADR.
+
+**Sequencing sub-decision: the operations tunnel is its own phase-1 checkpoint.**
+
+Within rebuild phase 1, the edge and public-cloud anchor stand up first, and the **operations tunnel is a distinct checkpoint** with its own [TR-04]({{< ref "../tech-requirements.md#tr-04" >}}) teardown — not one atomic foundations unit. Standing the tunnel up separately follows the plane separation this ADR already draws: the tunnel is operations-plane machinery, and folding it into the same unit as data-plane foundations would couple two things the decision deliberately keeps apart.
+
+The operative benefit is [TR-02]({{< ref "../tech-requirements.md#tr-02" >}}): a tunnel that fails to come up is torn down and retried against an intact cloud anchor, instead of costing a full foundations teardown and restarting the 60-minute budget. The cost is one more checkpoint boundary to define and keep deterministic. Phase 1 is still not complete until every checkpoint in it has passed — separate checkpoints subdivide the phase, they do not weaken [TR-03]({{< ref "../tech-requirements.md#tr-03" >}})'s both-environments-plus-connectivity bar.
+
+**Home-lab definitions sub-decision: a peer top-level definitions surface, tooling undecided.**
+
+The home-lab foundations are expressed as **version-controlled definitions in the same tracked-changes repository, as a peer top-level surface alongside `cloud/`**, exposing a teardown entry point per phase. That is the [TR-01]({{< ref "../tech-requirements.md#tr-01" >}})/TR-04 property this ADR fixes: home-lab state is not a second-class, hand-managed environment, and it is not a separate repository.
+
+**Which tooling realizes it is deliberately not decided here.** Terraform is the repository's only definitions precedent, but it is a weak fit for the bare-metal and OS-level state the home lab actually carries, and this ADR is at topology altitude — committing to a tool would pre-empt a component design that is better placed to weigh it. The constraint passed downstream is the property, not the mechanism: same repository, peer surface, deterministic per-phase teardown.
 
 ```mermaid
 flowchart LR
@@ -115,31 +147,64 @@ flowchart LR
 
 Both hosting targets sit behind the same edge; no tenant application is reachable by bypassing it.
 
+### Vendor admissibility (TR-18)
+
+The shape above commits to two vendor-bearing layers. Both were tested against [TR-18]({{< ref "../tech-requirements.md#tr-18" >}}) — configuration control through the tracked-changes surface, portable data export, and credential revocation/rotation without vendor cooperation — and **both are admissible**, with two residual risks recorded rather than waved off.
+
+**Edge vendor (today Cloudflare) — admissible.**
+
+* *Configuration control.* Edge configuration is driven by the `cloudflare` provider from the definitions repository (`cloud/mtls/cloudflare-gcp/`), so it is already inside the tracked-changes surface TR-01 requires. No dashboard-only step is load-bearing.
+* *Data export.* The edge is a proxy and holds no platform or tenant data of record — the export obligation is close to vacuous by construction. What it does hold, DNS zone state, is expressible as definitions and exportable independently of the vendor.
+* *Credential revocation/rotation.* API tokens are revocable by the operator alone. The origin keypair is generated **operator-side** (`tls_private_key`), never by the vendor, so rotation is a local operation and the private key is never vendor-held.
+
+*Residual risk 1 — origin certificates are edge-vendor-issued.* The origin certificate comes from the edge vendor's origin CA and is trusted only by that vendor's edge. Departing the edge vendor therefore means re-issuing origin certificates from another CA and re-pointing DNS. This is **migration work, not a lock-in that prevents departure** — it fails no limb of TR-18 — but it is the concrete cost of the "largest vendor-surface commitment" recorded below, and it should be sized rather than discovered.
+
+*Residual risk 2 — the trust anchor is fetched live from the vendor.* The authenticated-origin-pull CA trust anchor is retrieved over HTTP from a vendor-hosted URL at apply time. A rebuild therefore has a runtime dependency on vendor availability, which sits awkwardly against the TR-02 rebuild guarantee. Vendoring the trust anchor into the definitions repository, with a tracked update path, removes the dependency; the tech design owns that change.
+
+**Tunnel (today WireGuard) — admissible, and the least vendor-bearing layer.**
+
+WireGuard is self-hosted and configuration-file-driven, with keys generated locally: all three TR-18 limbs are satisfied without a vendor in the loop at all. The admissibility question properly attaches to the **endpoints carrying it** — the public-cloud side (already definitions-driven via `cloud/vpc-network/` and `cloud/network-load-balancer/`) and the home-lab-side network appliance terminating it.
+
+*Residual risk 3 — the home-lab tunnel endpoint is configured out-of-band.* Today the home-lab side of the tunnel is GUI-configured on the network appliance and documented as prose, which means it is **outside the tracked-changes surface** and is drift by TR-01's definition. This does not make the tunnel inadmissible — configuration control is fully available to the operator, which is what TR-18 tests — but it is an open TR-01 gap, and closing it is part of the home-lab definitions surface decided above.
+
 ### Consequences
 
 * Good, because the foundations phase reuses already-reproducible `cloud/` definitions, keeping the TR-02 ≤60-minute rebuild target reachable and honoring the reproducibility tiebreaker.
 * Good, because separating the application data plane (edge) from the operations plane (tunnel) gives TR-17 a clean external-reachability tier and a distinct internal-reachability tier, and prevents tenant traffic from ever depending on the operations tunnel.
 * Good, because routing both environments' tenant traffic through the one edge keeps mutual-auth and traffic-control duties in a single tier — a tenant's reachability story does not change when its placement changes, and placement stays a migratable property rather than a baked-in commitment.
 * Bad, because the dedicated edge vendor is the largest vendor-surface commitment, making it the weakest point against TR-18 and the vendor-independence tiebreaker; it must clear the TR-18 admissibility test.
-* Bad, because two valid hosting environments means the TR-17 inventory (compute, persistent storage, backup/DR, observability) must be realized **in both** — the requirement is that offerings are shared across tenants, not that they exist once, but a per-environment implementation of each offering is real duplicated surface, and every offering added later pays this cost twice. Divergence between the two implementations is a live risk that the tech design must contain.
+* Bad, because two valid hosting environments means TR-17 offerings may have to be realized **in both** — the requirement is that offerings are shared across tenants, not that they exist once, and a per-environment implementation of each offering is real duplicated surface. The offering-parity sub-decision **bounds** this cost rather than eliminating it: duplication is paid per offering per environment *on demand*, not up front for the whole inventory. Divergence between two implementations of the same offering remains a live risk the tech design must contain.
+* Bad, because unequal environments make placement fallible in a way full parity would not: a tenant needing an offering the target environment lacks **cannot** be placed there, and the platform must be able to say so rather than discover it during provisioning. This pushes a per-environment offering inventory into the tech design as a hard requirement.
+* Bad, because declining migration support means a placement decision made at onboarding is, in practice, durable for the tenant's lifetime — a wrong call is corrected by teardown and re-onboarding, with whatever data loss or downtime that entails borne as an operator exercise. Accepted because reachability continuity keeps the decision reversible later without reopening the topology.
+* Good, because separating the operations tunnel into its own phase-1 checkpoint keeps a tunnel failure from costing a full foundations teardown, protecting the TR-02 rebuild budget at the price of one additional checkpoint boundary.
+* Good, because the edge and tunnel layers were tested against TR-18 and cleared it, converting the accepted vendor-surface cost from an open risk into three named, ownable obligations (see Vendor admissibility above).
 * Bad, because hosting tenant workloads on managed cloud primitives deepens exposure to a single cloud provider, pressing on TR-18 (data export, credential rotation without vendor cooperation) more than a home-lab-only placement would. This is accepted because the capability tiebreaker ranks reproducibility above vendor independence, but it is a real concession and each managed primitive admitted as a tenant-hosting offering must pass TR-18 on its own.
-* Requires: the home-lab-side foundations must be expressed as version-controlled definitions (TR-01) — there is no `cloud/` analog for the home lab today; a downstream component design must define that surface and its TR-04 teardown.
-* Requires: an edge→cloud-anchor origin path for cloud-hosted tenant applications that enforces the same mutual-auth posture as the edge→home-lab path, so "reachable only through the edge" is an enforced property rather than a convention.
+* Requires: a downstream component design realizing the home-lab definitions surface decided above — same repository, peer to `cloud/`, deterministic per-phase teardown. The *shape* is settled here; the tooling is that design's to choose, and there is no `cloud/` analog to copy.
+* Requires: a per-environment offering inventory the placement path can consult, so a placement whose tenant needs an absent offering is refused rather than half-provisioned.
+* Requires: the home-lab edge→origin hop to enforce origin-pull client-certificate validation, matching the posture `cloud/mtls/cloudflare-gcp/` already gives the cloud anchor.
+* Requires: the edge trust anchor to be vendored into the definitions repository with a tracked update path, removing the rebuild-time dependency on vendor availability (residual risk 2).
+* Requires: the home-lab tunnel endpoint's configuration to be brought inside the tracked-changes surface as part of the home-lab definitions surface, closing the TR-01 drift gap (residual risk 3).
 
 ### Realization
 
-* `cloud/mtls/cloudflare-gcp/` — the Internet-facing edge trust (mTLS origin certs); the application data plane's entry point.
+* `cloud/mtls/cloudflare-gcp/` — the Internet-facing edge trust; the application data plane's entry point **and** the realization of the mutually-authenticated edge→cloud-anchor origin path decided above. Issues the operator-held origin keypair, obtains the origin certificate, and stores both plus the authenticated-origin-pull CA trust anchor in Secret Manager for the origin to validate against.
 * `cloud/https-load-balancer/`, `cloud/ip/`, `cloud/dns/` — external reachability plumbing behind the edge.
 * `cloud/vpc-network/` (`allow-wireguard` firewall tag) and `cloud/network-load-balancer/` (UDP gateway) — the operations-plane tunnel endpoints on the public-cloud side.
 * `cloud/rest-api/`, `cloud/https-load-balancer/`, `cloud/internal-application-load-balancer/` (Cloud Run backends and their network endpoint groups) and `cloud/firestore/` — the public-cloud-side tenant-hosting offerings: managed compute and persistent storage for cloud-placed tenants, fronted by the edge rather than exposed directly.
-* Home-lab-side platform offerings (tenant compute/persistent storage per TR-17) — **not yet** a `cloud/` module; a downstream component design owns how the home-lab foundations are expressed as definitions and torn down, and must reconcile its offering surface with the public-cloud-side equivalents above.
+* Home-lab-side platform offerings (tenant compute/persistent storage per TR-17) — **not yet realized**; a downstream component design owns the peer definitions surface decided above, its tooling, its per-phase teardown, its edge→origin mutual-auth enforcement, and bringing the home-lab tunnel endpoint's configuration in-repo. It need not mirror the public-cloud offering set (see the offering-parity sub-decision), but must declare what it does offer so placement can be constrained against it.
 * `tech-design.md` (composed later by `plan-tech-design`) will fold this shape into the final-state narrative alongside the other accepted ADRs.
 
 ## Open Questions
 
-* **Edge/tunnel vendor admissibility (TR-18).** The specific vendors realizing each layer are out of scope for this topology decision, but each must pass the TR-18 admissibility test (config control, data export, credential revocation/rotation without vendor cooperation). This is a downstream check, not a reopening of the shape.
-* **Home-lab definitions surface (TR-01/TR-04).** How the home-lab-side foundations are expressed as version-controlled definitions and given a deterministic per-phase teardown has no `cloud/` precedent yet; it belongs to a downstream component design.
-* **Ops-plane sequencing within phase 1 (TR-03/TR-04).** Whether the operations tunnel is stood up and torn down as its own checkpoint relative to the edge and the cloud anchor, or as a single foundations unit, is left to the tech design.
-* **Tenant placement policy (TR-17).** This ADR establishes that both environments are valid hosting targets; it does not decide how a given tenant's environment is chosen, who chooses it (operator, capability owner, or a declared workload property), or whether placement is re-negotiable after onboarding. This is a distinct decision and likely warrants its own ADR — it bears on the onboarding and modify engagement flows, not on the topology shape.
-* **Cross-environment offering parity (TR-17).** Whether every offering in the TR-17 inventory must exist in both environments before a tenant may be placed there, or whether environments may expose deliberately unequal offering sets (with placement constrained by what a tenant needs), is unresolved. The answer determines how much duplicated surface the platform actually carries.
-* **Migration between environments (TR-17).** Whether a tenant can be moved between environments after onboarding, and what that costs in data migration and downtime, is not decided here. Keeping reachability identical across environments is what makes this *possible*; it does not make it *supported*.
+One remains — **tenant placement policy**, which is its own ADR. The five realization questions this ADR previously carried are resolved and folded into the sections above.
+
+* **Tenant placement policy (TR-17).** *Still open, deliberately.* This ADR establishes that both environments are valid hosting targets and that placement is constrained by offering availability and fixed at onboarding; it does not decide how a given tenant's environment is chosen or who chooses it (operator, capability owner, or a declared workload property). That is a distinct decision warranting its own ADR — it bears on the onboarding and modify engagement flows, not on the topology shape. This ADR hands it two inputs: the per-environment offering inventory it must consult, and the fact that its choice is durable.
+
+### Resolved
+
+* **Edge/tunnel vendor admissibility (TR-18).** → **Both layers pass; three residual risks recorded as obligations.** The edge vendor clears all three limbs (provider-driven config in the definitions repo, no data of record held, operator-generated keypair and independently revocable tokens); the tunnel is self-hosted with no vendor in the loop. Residual: origin certificates are edge-vendor-issued (departure is migration work, not lock-in), the trust anchor is fetched live from the vendor at apply time, and the home-lab tunnel endpoint is configured out-of-band ([Vendor admissibility](#vendor-admissibility-tr-18), [Consequences](#consequences)).
+* **Home-lab definitions surface (TR-01/TR-04).** → **A peer top-level definitions surface in the same repository as `cloud/`, with a per-phase teardown entry point — tooling deliberately undecided.** The property is fixed here so the home lab cannot become a hand-managed second-class environment; the mechanism stays with a component design better placed to weigh Terraform's poor fit for bare-metal and OS-level state ([Decision Outcome](#decision-outcome), [Realization](#realization)).
+* **Ops-plane sequencing within phase 1 (TR-03/TR-04).** → **Its own checkpoint.** The edge and cloud anchor stand up first; the operations tunnel follows as a distinct checkpoint with its own TR-04 teardown. A failed tunnel is retried against an intact anchor instead of costing a full foundations teardown and the TR-02 budget. Phase 1 still completes only when every checkpoint passes ([Decision Outcome](#decision-outcome)).
+* **Cross-environment offering parity (TR-17).** → **No parity requirement; environments may expose deliberately unequal offering sets, and placement is constrained by what a tenant needs.** Full parity would make every future offering a double build before it could ship at all. The cost moved onto placement: the platform must know each environment's offerings and refuse placements it cannot satisfy ([Decision Outcome](#decision-outcome), [Consequences](#consequences)).
+* **Migration between environments (TR-17).** → **Not supported; placement is fixed at onboarding.** Moving a tenant means teardown and re-onboarding through the ordinary path — an operator exercise with no platform-guaranteed data-migration path or downtime budget. First-class migration would tax every stateful offering in both environments forever for undemonstrated demand. Reachability continuity keeps the decision reversible later without reopening the topology ([Decision Outcome](#decision-outcome), [Consequences](#consequences)).
+* **Edge→cloud-anchor origin path.** → **Mutually authenticated in both environments, enforced at the TLS layer.** The origin validates the edge's client certificate against the vendor's origin-pull trust anchor and refuses requests without one, so "reachable only through the edge" holds by enforcement rather than convention. Realized cloud-side today by `cloud/mtls/cloudflare-gcp/`; the home-lab side must match it ([Decision Outcome](#decision-outcome), [Realization](#realization)).


### PR DESCRIPTION
Closes #857.

Resolves five of ADR-0001's six open questions. Each decision is folded into the ADR body, and the Open Questions section is rewritten in resolved form (matching the pattern from #852).

## Decisions

| Question | Resolution |
|---|---|
| Offering parity (TR-17) | **No parity requirement.** Environments may expose deliberately unequal offering sets; placement is constrained by what a tenant actually needs. Full parity would make every future offering a double build before it could ship at all. |
| Migration (TR-17) | **Not supported.** Placement is fixed at onboarding; moving a tenant means teardown and re-onboarding. First-class migration would tax every stateful offering in both environments forever for undemonstrated demand. |
| Ops-plane sequencing (TR-03/TR-04) | **Its own phase-1 checkpoint.** A failed tunnel is retried against an intact cloud anchor instead of costing a full foundations teardown and the TR-02 budget. |
| Home-lab definitions (TR-01/TR-04) | **A peer top-level surface** in the same repository as `cloud/`, with per-phase teardown. Tooling deliberately left to component design — Terraform is a weak fit for bare-metal/OS-level state. |
| Vendor admissibility (TR-18) | **Both layers pass**, with three residual risks recorded as obligations. |
| Edge→origin path | **Mutually authenticated in both environments**, enforced at the TLS layer rather than by convention. |

## Notes for review

Two acceptance criteria were assessments rather than choices, so they were resolved directly:

- **TR-18.** The edge vendor clears all three limbs (config via the `cloudflare` provider already in-repo, no data of record held, operator-generated keypair). WireGuard is self-hosted with no vendor in the loop. Rather than a clean pass, three residual risks are named: origin certs are edge-vendor-issued (departure is migration work, not lock-in); the origin-pull trust anchor is fetched live from a vendor URL at apply time, which sits awkwardly against the TR-02 rebuild guarantee; and the home-lab tunnel endpoint is GUI-configured, so it is TR-01 drift today.
- **Edge→origin path.** `cloud/mtls/cloudflare-gcp/` already realizes this cloud-side; the ADR now states the property (origin-pull client-cert validation, origin refuses requests without one) and requires the home-lab side to match.

**Judgment call worth a look:** the unequal-offering-sets decision displaces cost onto placement, so the ADR now carries a hard requirement for a per-environment offering inventory — a placement whose tenant needs an absent offering must be *refused*, not discovered mid-provisioning. That obligation is inferred from the decision, not stated in the issue. The sequencing decision also explicitly does not weaken TR-03: separate checkpoints subdivide phase 1, they do not let it complete early.

**Tenant placement policy (#856) remains open by design.** This ADR hands it two inputs: the offering inventory it must consult, and the fact that its choice is durable.

## Verification

`hugo --gc --minify` builds clean (122 pages); all four new same-page anchors render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)